### PR TITLE
Images must be present in order to set status to active

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,8 +15,8 @@ class ApplicationController < ActionController::Base
   end
 
   def current_platform_admin?
-    current_user && current_user.platform_admin?
-  end
+      current_user && current_user.platform_admin?
+    end
 
   def current_vendor?
     current_user && current_user.vendor?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -46,7 +46,7 @@ class UsersController < ApplicationController
         redirect_to dashboard_path
       end
     else
-      flash.now[:error] = "Incorrect user information"
+      flash.now[:error] = "Incorrect user information. Please upload an image to change item status."
       render :edit
     end
   end

--- a/app/controllers/vendors/items_controller.rb
+++ b/app/controllers/vendors/items_controller.rb
@@ -25,6 +25,20 @@ class Vendors::ItemsController < Vendors::VendorsController
     end
   end
 
+  def edit
+    @item = current_vendor.items.find(params[:id])
+  end
+
+  def update
+    @item = current_vendor.items.find(params[:id])
+    if @item.update_attributes(item_params)
+      redirect_to vendor_items_path(vendor: current_vendor.url)
+    else
+      flash.now[:error] = "Incorrect user information"
+      render :edit
+    end
+  end
+
   private
 
   def item_params

--- a/app/views/vendors/items/_vendor_items_form.html.erb
+++ b/app/views/vendors/items/_vendor_items_form.html.erb
@@ -1,0 +1,36 @@
+<%= form_for @item, :url => vendor_items_path(vendor: current_vendor.url), :html => {class: "item_form", multipart: true} do |f| %>
+  <%= f.label :title %>
+  <%= f.text_field :title %>
+  <br>
+
+  <%= f.label :image_path %>
+  <%= f.text_field :image_path, placeholder: "Do not fill out this field if you are uploading an image" %>
+  <br>
+
+  <%= f.label :file_upload %>
+  <br><br>
+  <%= f.file_field :file_upload, class: "upload_file grey-text" %>
+  <br><br>
+
+  <%= f.label :price %>
+  <%= f.text_field :price %>
+  <br>
+
+  <%= f.label :category %>
+  <%= f.fields_for :category, @item.category do |category_form| %>
+    <%= f.select "category_id", options_from_collection_for_select(Category.all, "id", "name"), {prompt: nil}, {multiple: false} %>
+  <% end %>
+  <br>
+
+  <%= f.radio_button :status, "active" %>
+  <%= f.label :status, "Active", value: "active"%>
+  <%= f.radio_button :status, "inactive" %>
+  <%= f.label :status, "Inactive", value: "inactive" %>
+  <br><br>
+
+  <%= f.label :description %>
+  <%= f.text_area :description, class: "larger-text" %>
+  <br>
+
+  <%= f.submit class: "waves-effect waves-light btn " %>
+<% end %>

--- a/app/views/vendors/items/edit.html.erb
+++ b/app/views/vendors/items/edit.html.erb
@@ -1,0 +1,36 @@
+<%= form_for @item,:url => vendor_item_path(vendor: current_vendor.url, id: @item.id), :html => {class: "item_form", multipart: true} do |f| %>
+  <%= f.label :title %>
+  <%= f.text_field :title %>
+  <br>
+
+  <%= f.label :image_path %>
+  <%= f.text_field :image_path, placeholder: "Do not fill out this field if you are uploading an image" %>
+  <br>
+
+  <%= f.label :file_upload %>
+  <br><br>
+  <%= f.file_field :file_upload, class: "upload_file grey-text" %>
+  <br><br>
+
+  <%= f.label :price %>
+  <%= f.text_field :price %>
+  <br>
+
+  <%= f.label :category %>
+  <%= f.fields_for :category, @item.category do |category_form| %>
+    <%= f.select "category_id", options_from_collection_for_select(Category.all, "id", "name"), {prompt: nil}, {multiple: false} %>
+  <% end %>
+  <br>
+
+  <%= f.radio_button :status, "active" %>
+  <%= f.label :status, "Active", value: "active"%>
+  <%= f.radio_button :status, "inactive" %>
+  <%= f.label :status, "Inactive", value: "inactive" %>
+  <br><br>
+
+  <%= f.label :description %>
+  <%= f.text_area :description, class: "larger-text" %>
+  <br>
+
+  <%= f.submit class: "waves-effect waves-light btn " %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   resources :cart_items, only: [:create, :destroy, :update]
 
   namespace :vendors, path: ':vendor', as: :vendor do
-    resources :items, only: [:index, :show, :new, :create, :edit]
+    resources :items, only: [:index, :show, :new, :create, :edit, :update]
   end
 
   resources :users,

--- a/test/integration/P_images_show_inactive_status_if_default_test.rb
+++ b/test/integration/P_images_show_inactive_status_if_default_test.rb
@@ -2,33 +2,38 @@ require "test_helper"
 
 class ImagesShowInactiveStatusIfDefaultTest < ActionDispatch::IntegrationTest
   test "images default to inactive if there is no image" do
-    artist = create(:artist)
+    vendor = create(:vendor_with_user, status: 1)
+    user = vendor.users.first
     category = create(:category)
-    ApplicationController.any_instance.stubs(:current_user).returns(artist)
+    image_path = "https://petenelson.com/wp-content" \
+                 "/uploads/2011/08/ron-swanson-meat.jpg"
+    ApplicationController.any_instance.stubs(:current_user).returns(user)
 
-    visit dashboard_path
-    click_on "Add New Item"
-
-    assert_equal new_user_item_path(artist), current_path
+    visit new_vendor_item_path(vendor: vendor.url)
 
     fill_in "Title", with: "Meat"
     fill_in "Price", with: "10"
     fill_in "Description", with: "Salad? That's what my food eats"
     select category.name, from: "item_category_id"
     click_on "Create Item"
+
     item = Item.last
 
-    assert_equal artist, item.user
+    assert_equal vendor, item.vendor
     assert_equal "https://www.weefmgrenada.com/images/na4.jpg", item.image_path
-    assert_equal item_path(item), current_path
     assert_equal "inactive", item.status
 
-    visit edit_user_item_path(artist, item)
+    click_on "Edit Item"
     choose "Active"
     click_on "Update Item"
 
-    assert_equal item_path(item), current_path
-    assert page.has_content? "Please upload an image to change status."
     assert_equal "inactive", item.status
+
+    click_on "Edit Item"
+    fill_in "Image path", with: image_path
+    choose "Active"
+    click_on "Update Item"
+
+    assert_equal "active", item.reload.status
   end
 end


### PR DESCRIPTION
When a vendor creates an item the status will be automatically set to inactive if there is no image present. Editing the item and adding an image allows a user to set status to active. 
