### PR TITLE
[WIP] Start admin edits user functionality

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,8 +24,10 @@ class UsersController < ApplicationController
   end
 
   def show
-    if current_user
+    if current_platform_admin?
       @user = User.find_by_slug(params[:slug])
+    elsif current_user?
+      @user = User.find(current_user.id)
     else
       render file: "public/404"
     end

--- a/test/integration/P_admin_can_edit_user_profile_test.rb
+++ b/test/integration/P_admin_can_edit_user_profile_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class AdminCanEditUserProfileTest < ActionDispatch::IntegrationTest
+  test "platform admins can edit user profiles and view order history" do
+    admin = create(:user, role: 2)
+    user = create(:user)
+
+    visit dashboard_path(user: user.slug)
+    click_on "Edit Info"
+
+    fill_in "First Name", with: "Joshua"
+    assert page.has_content?("Joshua")
+
+    click_on "Order History"
+    assert page.has_content?("Order For: #{user.first_name} #{user.last_name}")
+  end
+end


### PR DESCRIPTION
Waiting on collaborator functionality to see if this is necessary. Probably adjusting scope of test to verify that admins can add and edit collaborators, not necessary to edit user dashboards as users are the only ones who can access that info anyway. 
